### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a PrivX connector
 og:title: Set up a PrivX connector - C1 docs
-og:description: Integrate your PrivX Enterprise instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for PrivX. Integrate your PrivX Enterprise instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for PrivX. Integrate your PrivX instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for PrivX. Integrate your PrivX instance with C1 for unified visibility and governance over user access."
 sidebarTitle: PrivX
 ---
 
@@ -65,7 +65,7 @@ Click **Save**.
 Scroll down to the **Credentials** section of the page. Carefully copy and save the OAuth Client ID and Client Secret, and the API Client ID and Client Secret. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the PrivX connector
 
@@ -122,7 +122,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your PrivX connector is now pulling access data into C1.
+**Done.** Your PrivX connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 
@@ -244,7 +244,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your PrivX connector is now pulling access data into C1.
+**Done.** Your PrivX connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines