### PR TITLE
fix: mark api-client-secret and oauth-client-secret as isSecret in config schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ var (
 	ApiClientSecretField = field.StringField(
 		"api-client-secret",
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 		field.WithDescription("The API Client Secret (a base64 string.)"),
 	)
 	OauthClientIdField = field.StringField(
@@ -28,6 +29,7 @@ var (
 	OauthClientSecretField = field.StringField(
 		"oauth-client-secret",
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 		field.WithDescription("The OAuth Client Secret (a base64 string.)"),
 	)
 


### PR DESCRIPTION
## Summary

Marks credential field(s) `api-client-secret` and `oauth-client-secret` (PrivX API/OAuth client secrets) as secret in this connector's config so the credential is stored and handled as a secret rather than plaintext.

This connector defines its config in Go (`field` package), not a `config.yaml`. Secret-ness is the `field.WithIsSecret(true)` option on the field — the authoritative source. There is no committed `config_schema.json` in this repo, and the generated `conf.gen.go` is a mapstructure struct that carries no secret metadata, so the one-line `config.go` change is the complete fix and a CI regen produces no additional diff (no race).

## BREAKING

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

## Audit

Part of the connector config secret-ness audit (phase 13). Found via systematic review of credential fields lacking `isSecret`.

Do not merge — left open for review.

<!-- stargate: connector-secret-audit-phase13 -->