### PR TITLE
CXH-1892: containerize connector

### DIFF
--- a/cmd/baton-privx/config.go
+++ b/cmd/baton-privx/config.go
@@ -1,1 +1,0 @@
-package main

--- a/cmd/baton-privx/main.go
+++ b/cmd/baton-privx/main.go
@@ -2,65 +2,19 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	cfg "github.com/conductorone/baton-privx/pkg/config"
 	"github.com/conductorone/baton-privx/pkg/connector"
 	"github.com/conductorone/baton-sdk/pkg/config"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
-	"github.com/conductorone/baton-sdk/pkg/types"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 )
 
 var version = "dev"
 
 func main() {
 	ctx := context.Background()
-	_, cmd, err := config.DefineConfiguration(
-		ctx,
-		"baton-privx",
-		getConnector,
-		cfg.Config,
-		connectorrunner.WithDefaultCapabilitiesConnectorBuilder(&connector.Connector{}),
+	config.RunConnector(ctx, "baton-privx", version, cfg.Config,
+		connector.NewLambdaConnector,
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{}),
 	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cmd.Version = version
-
-	err = cmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-}
-
-func getConnector(ctx context.Context, c *cfg.Privx) (types.ConnectorServer, error) {
-	l := ctxzap.Extract(ctx)
-
-	cb, err := connector.New(
-		ctx,
-		c.BaseUrl,
-		c.ApiClientId,
-		c.ApiClientSecret,
-		c.OauthClientId,
-		c.OauthClientSecret,
-	)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	conn, err := connectorbuilder.NewConnector(ctx, cb)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	return conn, nil
 }

--- a/config_schema.json
+++ b/config_schema.json
@@ -94,7 +94,8 @@
     },
     {
       "name": "base-url",
-      "description": "The hostname (URL) for your PrivX instance",
+      "displayName": "Base URL",
+      "placeholder": "Your PrivX base URL",
       "isRequired": true,
       "stringField": {
         "rules": {
@@ -103,46 +104,53 @@
       }
     },
     {
-      "name": "api-client-id",
-      "description": "The API Client ID (a UUID.)",
-      "isRequired": true,
-      "stringField": {
-        "rules": {
-          "isRequired": true
-        }
-      }
+      "name": "privx-client-id",
+      "displayName": "Client ID",
+      "placeholder": "Your PrivX client ID",
+      "stringField": {}
     },
     {
-      "name": "api-client-secret",
-      "description": "The API Client Secret (a base64 string.)",
-      "isRequired": true,
+      "name": "privx-client-secret",
+      "displayName": "Client secret",
+      "placeholder": "Your PrivX client secret",
       "isSecret": true,
-      "stringField": {
-        "rules": {
-          "isRequired": true
-        }
-      }
+      "stringField": {}
     },
     {
       "name": "oauth-client-id",
-      "description": "The OAuth Client ID (e.g. \"privx-external\".)",
-      "isRequired": true,
-      "stringField": {
-        "rules": {
-          "isRequired": true
-        }
-      }
+      "displayName": "OAuth client ID",
+      "placeholder": "Your PrivX OAuth client ID",
+      "stringField": {}
     },
     {
       "name": "oauth-client-secret",
-      "description": "The OAuth Client Secret (a base64 string.)",
-      "isRequired": true,
+      "displayName": "OAuth client secret",
+      "placeholder": "Your PrivX OAuth client secret",
       "isSecret": true,
-      "stringField": {
-        "rules": {
-          "isRequired": true
-        }
-      }
+      "stringField": {}
+    }
+  ],
+  "displayName": "PrivX",
+  "helpUrl": "/docs/baton/privx",
+  "iconUrl": "/static/app-icons/privx.svg",
+  "fieldGroups": [
+    {
+      "name": "privx-group-oauth",
+      "displayName": "OAuth",
+      "fields": [
+        "base-url",
+        "oauth-client-id",
+        "oauth-client-secret"
+      ]
+    },
+    {
+      "name": "privx-group-client-secret",
+      "displayName": "Client secret",
+      "fields": [
+        "base-url",
+        "privx-client-id",
+        "privx-client-secret"
+      ]
     }
   ]
 }

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -188,8 +188,8 @@ stringData:
   BATON_CLIENT_SECRET: <C1 client secret>
   
   # PrivX credentials, option 1
-  BATON_API_CLIENT_ID: <PrivX API client ID>
-  BATON_API_CLIENT_SECRET: <PrivX API client secret>
+  BATON_PRIVX_CLIENT_ID: <PrivX client ID>
+  BATON_PRIVX_CLIENT_SECRET: <PrivX client secret>
   BATON_BASE_URL: <PrivX instance base URL>
 
   # PrivX credentials, option 2

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -5,8 +5,8 @@ import "reflect"
 
 type Privx struct {
 	BaseUrl string `mapstructure:"base-url"`
-	ApiClientId string `mapstructure:"api-client-id"`
-	ApiClientSecret string `mapstructure:"api-client-secret"`
+	ClientId string `mapstructure:"client-id"`
+	ClientSecret string `mapstructure:"client-secret"`
 	OauthClientId string `mapstructure:"oauth-client-id"`
 	OauthClientSecret string `mapstructure:"oauth-client-secret"`
 }

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -5,8 +5,8 @@ import "reflect"
 
 type Privx struct {
 	BaseUrl string `mapstructure:"base-url"`
-	ClientId string `mapstructure:"client-id"`
-	ClientSecret string `mapstructure:"client-secret"`
+	PrivxClientId string `mapstructure:"privx-client-id"`
+	PrivxClientSecret string `mapstructure:"privx-client-secret"`
 	OauthClientId string `mapstructure:"oauth-client-id"`
 	OauthClientSecret string `mapstructure:"oauth-client-secret"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 var (
 	BaseUrlField = field.StringField(
 		"base-url",
+		field.WithRequired(true),
 		field.WithDisplayName("Base URL"),
 		field.WithPlaceholder("Your PrivX base URL"),
 	)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,28 +8,36 @@ var (
 	BaseUrlField = field.StringField(
 		"base-url",
 		field.WithRequired(true),
+		field.WithDisplayName("Base URL"),
+		field.WithPlaceholder("https://your-privx-instance.example.com"),
 		field.WithDescription("The hostname (URL) for your PrivX instance"),
 	)
 	ApiClientIdField = field.StringField(
 		"api-client-id",
 		field.WithRequired(true),
+		field.WithDisplayName("API Client ID"),
+		field.WithPlaceholder("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
 		field.WithDescription("The API Client ID (a UUID.)"),
 	)
 	ApiClientSecretField = field.StringField(
 		"api-client-secret",
 		field.WithRequired(true),
 		field.WithIsSecret(true),
+		field.WithDisplayName("API Client Secret"),
 		field.WithDescription("The API Client Secret (a base64 string.)"),
 	)
 	OauthClientIdField = field.StringField(
 		"oauth-client-id",
 		field.WithRequired(true),
+		field.WithDisplayName("OAuth Client ID"),
+		field.WithPlaceholder("privx-external"),
 		field.WithDescription("The OAuth Client ID (e.g. \"privx-external\".)"),
 	)
 	OauthClientSecretField = field.StringField(
 		"oauth-client-secret",
 		field.WithRequired(true),
 		field.WithIsSecret(true),
+		field.WithDisplayName("OAuth Client Secret"),
 		field.WithDescription("The OAuth Client Secret (a base64 string.)"),
 	)
 
@@ -43,4 +51,9 @@ var (
 )
 
 //go:generate go run ./gen
-var Config = field.NewConfiguration(ConfigurationFields)
+var Config = field.NewConfiguration(
+	ConfigurationFields,
+	field.WithConnectorDisplayName("PrivX"),
+	field.WithIconUrl("/static/app-icons/privx.svg"),
+	field.WithHelpUrl("/docs/baton/privx"),
+)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,44 +7,36 @@ import (
 var (
 	BaseUrlField = field.StringField(
 		"base-url",
-		field.WithRequired(true),
 		field.WithDisplayName("Base URL"),
-		field.WithPlaceholder("https://your-privx-instance.example.com"),
-		field.WithDescription("The hostname (URL) for your PrivX instance"),
+		field.WithPlaceholder("Your PrivX base URL"),
 	)
-	ApiClientIdField = field.StringField(
-		"api-client-id",
-		field.WithRequired(true),
-		field.WithDisplayName("API Client ID"),
-		field.WithPlaceholder("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
-		field.WithDescription("The API Client ID (a UUID.)"),
+	ClientIdField = field.StringField(
+		"client-id",
+		field.WithDisplayName("Client ID"),
+		field.WithPlaceholder("Your PrivX client ID"),
 	)
-	ApiClientSecretField = field.StringField(
-		"api-client-secret",
-		field.WithRequired(true),
+	ClientSecretField = field.StringField(
+		"client-secret",
 		field.WithIsSecret(true),
-		field.WithDisplayName("API Client Secret"),
-		field.WithDescription("The API Client Secret (a base64 string.)"),
+		field.WithDisplayName("Client secret"),
+		field.WithPlaceholder("Your PrivX client secret"),
 	)
 	OauthClientIdField = field.StringField(
 		"oauth-client-id",
-		field.WithRequired(true),
-		field.WithDisplayName("OAuth Client ID"),
-		field.WithPlaceholder("privx-external"),
-		field.WithDescription("The OAuth Client ID (e.g. \"privx-external\".)"),
+		field.WithDisplayName("OAuth client ID"),
+		field.WithPlaceholder("Your PrivX OAuth client ID"),
 	)
 	OauthClientSecretField = field.StringField(
 		"oauth-client-secret",
-		field.WithRequired(true),
 		field.WithIsSecret(true),
-		field.WithDisplayName("OAuth Client Secret"),
-		field.WithDescription("The OAuth Client Secret (a base64 string.)"),
+		field.WithDisplayName("OAuth client secret"),
+		field.WithPlaceholder("Your PrivX OAuth client secret"),
 	)
 
 	ConfigurationFields = []field.SchemaField{
 		BaseUrlField,
-		ApiClientIdField,
-		ApiClientSecretField,
+		ClientIdField,
+		ClientSecretField,
 		OauthClientIdField,
 		OauthClientSecretField,
 	}
@@ -56,4 +48,16 @@ var Config = field.NewConfiguration(
 	field.WithConnectorDisplayName("PrivX"),
 	field.WithIconUrl("/static/app-icons/privx.svg"),
 	field.WithHelpUrl("/docs/baton/privx"),
+	field.WithFieldGroups([]field.SchemaFieldGroup{
+		{
+			Name:        "privx-group-oauth",
+			DisplayName: "OAuth",
+			Fields:      []field.SchemaField{BaseUrlField, OauthClientIdField, OauthClientSecretField},
+		},
+		{
+			Name:        "privx-group-client-secret",
+			DisplayName: "Client secret",
+			Fields:      []field.SchemaField{BaseUrlField, ClientIdField, ClientSecretField},
+		},
+	}),
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,12 +11,12 @@ var (
 		field.WithPlaceholder("Your PrivX base URL"),
 	)
 	ClientIdField = field.StringField(
-		"client-id",
+		"privx-client-id",
 		field.WithDisplayName("Client ID"),
 		field.WithPlaceholder("Your PrivX client ID"),
 	)
 	ClientSecretField = field.StringField(
-		"client-secret",
+		"privx-client-secret",
 		field.WithIsSecret(true),
 		field.WithDisplayName("Client secret"),
 		field.WithPlaceholder("Your PrivX client secret"),

--- a/pkg/connector/client/privx.go
+++ b/pkg/connector/client/privx.go
@@ -17,36 +17,36 @@ type PrivXClient struct {
 	RoleStore  rolestore.RoleStore
 }
 
-func NewPrivXClient(
-	ctx context.Context,
-	baseUrl string,
-	apiClientId string,
-	apiClientSecret string,
-	oauthClientId string,
-	oauthClientSecret string,
-) (*PrivXClient, error) {
-	baseUrl = strings.Trim(baseUrl, "/")
-
-	authorizer := oauth.With(
-		restapi.New(
-			restapi.BaseURL(baseUrl),
-		),
-		oauth.Access(apiClientId),
-		oauth.Secret(apiClientSecret),
-		oauth.Digest(oauthClientId, oauthClientSecret),
-	)
-
+func newPrivXClient(baseUrl string, authorizer restapi.Authorizer) *PrivXClient {
 	roleStore := rolestore.New(
 		restapi.New(
 			restapi.Auth(authorizer),
 			restapi.BaseURL(baseUrl),
 		),
 	)
-
 	return &PrivXClient{
 		Authorizer: authorizer,
 		RoleStore:  *roleStore,
-	}, nil
+	}
+}
+
+func NewPrivXClientWithOAuth(ctx context.Context, baseUrl, oauthClientId, oauthClientSecret string) (*PrivXClient, error) {
+	baseUrl = strings.Trim(baseUrl, "/")
+	authorizer := oauth.With(
+		restapi.New(restapi.BaseURL(baseUrl)),
+		oauth.Digest(oauthClientId, oauthClientSecret),
+	)
+	return newPrivXClient(baseUrl, authorizer), nil
+}
+
+func NewPrivXClientWithClientSecret(ctx context.Context, baseUrl, clientId, clientSecret string) (*PrivXClient, error) {
+	baseUrl = strings.Trim(baseUrl, "/")
+	authorizer := oauth.With(
+		restapi.New(restapi.BaseURL(baseUrl)),
+		oauth.Access(clientId),
+		oauth.Secret(clientSecret),
+	)
+	return newPrivXClient(baseUrl, authorizer), nil
 }
 
 func getNextToken(start, found, pageSize int) string {

--- a/pkg/connector/client/privx.go
+++ b/pkg/connector/client/privx.go
@@ -34,7 +34,8 @@ func NewPrivXClientWithOAuth(ctx context.Context, baseUrl, oauthClientId, oauthC
 	baseUrl = strings.Trim(baseUrl, "/")
 	authorizer := oauth.With(
 		restapi.New(restapi.BaseURL(baseUrl)),
-		oauth.Digest(oauthClientId, oauthClientSecret),
+		oauth.Access(oauthClientId),
+		oauth.Secret(oauthClientSecret),
 	)
 	return newPrivXClient(baseUrl, authorizer), nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -13,14 +13,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 )
 
-type Config struct {
-	BaseUrl           string
-	PrivxClientId     string
-	PrivxClientSecret string
-	OAuthClientID     string
-	OAuthClientSecret string
-}
-
 type Connector struct {
 	client client.PrivXClient
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 
+	cfg "github.com/conductorone/baton-privx/pkg/config"
 	"github.com/conductorone/baton-privx/pkg/connector/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 )
 
@@ -23,9 +25,9 @@ type Connector struct {
 	client client.PrivXClient
 }
 
-// ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
-func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	return []connectorbuilder.ResourceSyncer{
+// ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
+func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	return []connectorbuilder.ResourceSyncerV2{
 		newUserBuilder(d.client),
 		newRoleBuilder(d.client),
 	}
@@ -40,8 +42,8 @@ func (d *Connector) Asset(ctx context.Context, asset *v2.AssetRef) (string, io.R
 // Metadata returns metadata about the connector.
 func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 	return &v2.ConnectorMetadata{
-		DisplayName: "My Baton Connector",
-		Description: "The template implementation of a baton connector",
+		DisplayName: "PrivX",
+		Description: "Baton connector for PrivX",
 	}, nil
 }
 
@@ -79,4 +81,20 @@ func New(
 	}
 
 	return &Connector{client: *privXClient}, nil
+}
+
+// NewLambdaConnector returns a new ConnectorBuilderV2 for use with RunConnector / Lambda.
+func NewLambdaConnector(ctx context.Context, ac *cfg.Privx, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	c, err := New(
+		ctx,
+		ac.BaseUrl,
+		ac.ApiClientId,
+		ac.ApiClientSecret,
+		ac.OauthClientId,
+		ac.OauthClientSecret,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c, nil, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -15,8 +15,8 @@ import (
 
 type Config struct {
 	BaseUrl           string
-	ApiClientId       string
-	ApiClientSecret   string
+	ClientId          string
+	ClientSecret      string
 	OAuthClientID     string
 	OAuthClientSecret string
 }
@@ -58,41 +58,37 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 	return nil, nil
 }
 
-// New returns a new instance of the connector.
-func New(
-	ctx context.Context,
-	baseUrl,
-	apiClientId,
-	apiClientSecret,
-	oAuthClientID,
-	oAuthClientSecret string,
-) (*Connector, error) {
-	privXClient, err := client.NewPrivXClient(
-		ctx,
-		baseUrl,
-		apiClientId,
-		apiClientSecret,
-		oAuthClientID,
-		oAuthClientSecret,
-	)
-
+// NewWithOAuth returns a new instance of the connector using OAuth authentication.
+func NewWithOAuth(ctx context.Context, baseUrl, oAuthClientID, oAuthClientSecret string) (*Connector, error) {
+	privXClient, err := client.NewPrivXClientWithOAuth(ctx, baseUrl, oAuthClientID, oAuthClientSecret)
 	if err != nil {
 		return nil, err
 	}
+	return &Connector{client: *privXClient}, nil
+}
 
+// NewWithClientSecret returns a new instance of the connector using client secret authentication.
+func NewWithClientSecret(ctx context.Context, baseUrl, clientId, clientSecret string) (*Connector, error) {
+	privXClient, err := client.NewPrivXClientWithClientSecret(ctx, baseUrl, clientId, clientSecret)
+	if err != nil {
+		return nil, err
+	}
 	return &Connector{client: *privXClient}, nil
 }
 
 // NewLambdaConnector returns a new ConnectorBuilderV2 for use with RunConnector / Lambda.
-func NewLambdaConnector(ctx context.Context, ac *cfg.Privx, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
-	c, err := New(
-		ctx,
-		ac.BaseUrl,
-		ac.ApiClientId,
-		ac.ApiClientSecret,
-		ac.OauthClientId,
-		ac.OauthClientSecret,
-	)
+func NewLambdaConnector(ctx context.Context, ac *cfg.Privx, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	var c *Connector
+	var err error
+
+	switch opts.SelectedAuthMethod {
+	case "privx-group-oauth":
+		c, err = NewWithOAuth(ctx, ac.BaseUrl, ac.OauthClientId, ac.OauthClientSecret)
+	case "privx-group-client-secret":
+		c, err = NewWithClientSecret(ctx, ac.BaseUrl, ac.ClientId, ac.ClientSecret)
+	default:
+		return nil, nil, fmt.Errorf("baton-privx: unknown auth method: %s", opts.SelectedAuthMethod)
+	}
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -15,8 +15,8 @@ import (
 
 type Config struct {
 	BaseUrl           string
-	ClientId          string
-	ClientSecret      string
+	PrivxClientId     string
+	PrivxClientSecret string
 	OAuthClientID     string
 	OAuthClientSecret string
 }
@@ -85,7 +85,7 @@ func NewLambdaConnector(ctx context.Context, ac *cfg.Privx, opts *cli.ConnectorO
 	case "privx-group-oauth":
 		c, err = NewWithOAuth(ctx, ac.BaseUrl, ac.OauthClientId, ac.OauthClientSecret)
 	case "privx-group-client-secret":
-		c, err = NewWithClientSecret(ctx, ac.BaseUrl, ac.ClientId, ac.ClientSecret)
+		c, err = NewWithClientSecret(ctx, ac.BaseUrl, ac.PrivxClientId, ac.PrivxClientSecret)
 	default:
 		return nil, nil, fmt.Errorf("baton-privx: unknown auth method: %s", opts.SelectedAuthMethod)
 	}

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -8,7 +8,6 @@ import (
 	"github.com/conductorone/baton-privx/pkg/connector/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -28,19 +27,18 @@ func (o *roleBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 	return roleResourceType
 }
 
-// List returns all the users from the database as resource objects.
-// Users include a UserTrait because they are the 'shape' of a standard user.
+// List returns all the roles from the upstream service as resource objects.
 func (o *roleBuilder) List(
 	ctx context.Context,
 	parentResourceID *v2.ResourceId,
-	pToken *pagination.Token,
+	opts resource.SyncOpAttrs,
 ) (
 	[]*v2.Resource,
-	string,
-	annotations.Annotations,
+	*resource.SyncOpResults,
 	error,
 ) {
 	logger := ctxzap.Extract(ctx)
+	pToken := &opts.PageToken
 
 	offset, limit, err := parsePageToken(pToken)
 	if err != nil {
@@ -49,8 +47,8 @@ func (o *roleBuilder) List(
 
 	privXRoles, nextToken, err := o.client.GetRoles(ctx, offset, limit)
 	if err != nil {
-		logger.Debug("Error fetching users", zap.Error(err))
-		return nil, "", nil, err
+		logger.Debug("Error fetching roles", zap.Error(err))
+		return nil, nil, err
 	}
 
 	roleResources := make([]*v2.Resource, 0)
@@ -58,38 +56,43 @@ func (o *roleBuilder) List(
 		roleCopy := role
 		newResource, err := roleResource(ctx, &roleCopy)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		roleResources = append(roleResources, newResource)
 	}
 
-	return roleResources, nextToken, nil, nil
+	if nextToken == "" {
+		return roleResources, nil, nil
+	}
+
+	return roleResources, &resource.SyncOpResults{NextPageToken: nextToken}, nil
 }
 
 func (o *roleBuilder) Entitlements(
 	_ context.Context,
-	resource *v2.Resource,
-	_ *pagination.Token,
-) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+	res *v2.Resource,
+	_ resource.SyncOpAttrs,
+) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
 	entitlements := []*v2.Entitlement{
 		entitlement.NewAssignmentEntitlement(
-			resource,
+			res,
 			EntitlementAssigned,
 			entitlement.WithGrantableTo(roleResourceType),
-			entitlement.WithDescription(fmt.Sprintf("Has %s role membership", resource.DisplayName)),
-			entitlement.WithDisplayName(fmt.Sprintf("%s role %s", resource.DisplayName, EntitlementAssigned)),
+			entitlement.WithDescription(fmt.Sprintf("Has %s role membership", res.DisplayName)),
+			entitlement.WithDisplayName(fmt.Sprintf("%s role %s", res.DisplayName, EntitlementAssigned)),
 		),
 	}
-	return entitlements, "", nil, nil
+	return entitlements, nil, nil
 }
 
 func (o *roleBuilder) Grants(
 	ctx context.Context,
-	resource *v2.Resource,
-	pToken *pagination.Token,
-) ([]*v2.Grant, string, annotations.Annotations, error) {
+	res *v2.Resource,
+	opts resource.SyncOpAttrs,
+) ([]*v2.Grant, *resource.SyncOpResults, error) {
 	logger := ctxzap.Extract(ctx)
+	pToken := &opts.PageToken
 	logger.Debug(
 		"Starting call to Roles.Grants",
 		zap.String("pToken", pToken.Token),
@@ -102,12 +105,12 @@ func (o *roleBuilder) Grants(
 
 	privXUsers, nextToken, err := o.client.GetUsersForRole(
 		ctx,
-		resource.Id.Resource,
+		res.Id.Resource,
 		offset,
 		limit,
 	)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var roleAssignments []*v2.Grant
@@ -115,7 +118,7 @@ func (o *roleBuilder) Grants(
 		roleAssignments = append(
 			roleAssignments,
 			grant.NewGrant(
-				resource,
+				res,
 				EntitlementAssigned,
 				&v2.ResourceId{
 					ResourceType: userResourceType.Id,
@@ -125,14 +128,18 @@ func (o *roleBuilder) Grants(
 		)
 	}
 
-	return roleAssignments, nextToken, nil, nil
+	if nextToken == "" {
+		return roleAssignments, nil, nil
+	}
+
+	return roleAssignments, &resource.SyncOpResults{NextPageToken: nextToken}, nil
 }
 
 func (o *roleBuilder) Grant(
 	ctx context.Context,
 	principal *v2.Resource,
-	entitlement *v2.Entitlement,
-) (annotations.Annotations, error) {
+	ent *v2.Entitlement,
+) ([]*v2.Grant, annotations.Annotations, error) {
 	logger := ctxzap.Extract(ctx)
 
 	if principal.Id.ResourceType != userResourceType.Id {
@@ -141,25 +148,30 @@ func (o *roleBuilder) Grant(
 			zap.String("principal_type", principal.Id.ResourceType),
 			zap.String("principal_id", principal.Id.Resource),
 		)
-		return nil, fmt.Errorf("baton-privx: only users can be assigned roles")
+		return nil, nil, fmt.Errorf("baton-privx: only users can be assigned roles")
 	}
 
 	err := o.client.GrantRole(
 		ctx,
 		principal.Id.Resource,
-		entitlement.Resource.Id.Resource,
+		ent.Resource.Id.Resource,
 	)
-	return nil, err
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newGrant := grant.NewGrant(ent.Resource, EntitlementAssigned, principal.Id)
+	return []*v2.Grant{newGrant}, nil, nil
 }
 
 func (o *roleBuilder) Revoke(
 	ctx context.Context,
-	grant *v2.Grant,
+	g *v2.Grant,
 ) (annotations.Annotations, error) {
 	logger := ctxzap.Extract(ctx)
 
-	entitlement := grant.Entitlement
-	principal := grant.Principal
+	ent := g.Entitlement
+	principal := g.Principal
 
 	if principal.Id.ResourceType != userResourceType.Id {
 		logger.Warn(
@@ -173,7 +185,7 @@ func (o *roleBuilder) Revoke(
 	err := o.client.RevokeRole(
 		ctx,
 		principal.Id.Resource,
-		entitlement.Resource.Id.Resource,
+		ent.Resource.Id.Resource,
 	)
 	return nil, err
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -6,8 +6,6 @@ import (
 	"github.com/SSHcom/privx-sdk-go/api/rolestore"
 	"github.com/conductorone/baton-privx/pkg/connector/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
@@ -26,14 +24,14 @@ func (o *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 func (o *userBuilder) List(
 	ctx context.Context,
 	parentResourceID *v2.ResourceId,
-	pToken *pagination.Token,
+	opts resource.SyncOpAttrs,
 ) (
 	[]*v2.Resource,
-	string,
-	annotations.Annotations,
+	*resource.SyncOpResults,
 	error,
 ) {
 	logger := ctxzap.Extract(ctx)
+	pToken := &opts.PageToken
 	logger.Debug(
 		"Starting call to Users.List",
 		zap.String("pToken", pToken.Token),
@@ -50,7 +48,7 @@ func (o *userBuilder) List(
 			"Error fetching users",
 			zap.Error(err),
 		)
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	userResources := make([]*v2.Resource, 0)
@@ -58,31 +56,35 @@ func (o *userBuilder) List(
 		userCopy := user
 		newUserResource, err := userResource(ctx, &userCopy)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		userResources = append(userResources, newUserResource)
 	}
 
-	return userResources, nextToken, nil, nil
+	if nextToken == "" {
+		return userResources, nil, nil
+	}
+
+	return userResources, &resource.SyncOpResults{NextPageToken: nextToken}, nil
 }
 
 // Entitlements always returns an empty slice for users.
 func (o *userBuilder) Entitlements(
 	_ context.Context,
-	resource *v2.Resource,
-	_ *pagination.Token,
-) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+	_ *v2.Resource,
+	_ resource.SyncOpAttrs,
+) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
 func (o *userBuilder) Grants(
 	ctx context.Context,
-	resource *v2.Resource,
-	pToken *pagination.Token,
-) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+	_ *v2.Resource,
+	_ resource.SyncOpAttrs,
+) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newUserBuilder(client client.PrivXClient) *userBuilder {

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -32,13 +32,11 @@ func TestUsersList(t *testing.T) {
 		)
 		defer server.Close()
 
-		privXClient, err := client.NewPrivXClient(
+		privXClient, err := client.NewPrivXClientWithClientSecret(
 			ctx,
 			server.URL,
-			"apiClientId",
-			"apiClientSecret",
-			"oauthClientId",
-			"oauthClientSecret",
+			"clientId",
+			"clientSecret",
 		)
 		require.Nil(t, err)
 		userBuilder := newUserBuilder(*privXClient)
@@ -71,13 +69,11 @@ func TestUsersList(t *testing.T) {
 		)
 		defer server.Close()
 
-		privXClient, err := client.NewPrivXClient(
+		privXClient, err := client.NewPrivXClientWithClientSecret(
 			ctx,
 			server.URL,
-			"apiClientId",
-			"apiClientSecret",
-			"oauthClientId",
-			"oauthClientSecret",
+			"clientId",
+			"clientSecret",
 		)
 		require.Nil(t, err)
 		userBuilder := newUserBuilder(*privXClient)

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,23 +14,52 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newMockPrivXServer creates a test server that handles the PrivX OAuth flow
+// (Authorization Code Grant) and serves fixture data for API endpoints.
+func newMockPrivXServer(fixturePath string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/api/v1/oauth/authorize":
+			// The SDK sends state as a query param; echo it back as the token so
+			// the login endpoint can return the same state value.
+			state := r.URL.Query().Get("state")
+			w.Header().Set("Location", "/privx/oauth-callback?token="+state)
+			w.WriteHeader(http.StatusTemporaryRedirect)
+
+		case "/auth/api/v1/login":
+			var body struct {
+				Token string `json:"token"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			w.Header().Set(uhttp.ContentType, "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"code":  "test-code",
+				"state": body.Token, // token == original state, satisfying the SDK check
+			})
+
+		case "/auth/api/v1/oauth/token":
+			w.Header().Set(uhttp.ContentType, "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "test-token",
+				"token_type":   "bearer",
+				"expires_in":   3600,
+			})
+
+		default:
+			w.Header().Set(uhttp.ContentType, "application/json")
+			w.WriteHeader(http.StatusOK)
+			data, _ := os.ReadFile(fixturePath)
+			_, _ = w.Write(data)
+		}
+	}))
+}
+
 func TestUsersList(t *testing.T) {
 	ctx := context.Background()
 	t.Run("should receive users", func(t *testing.T) {
-		server := httptest.NewServer(
-			http.HandlerFunc(
-				func(writer http.ResponseWriter, request *http.Request) {
-					writer.Header().Set(uhttp.ContentType, "application/json")
-					writer.WriteHeader(http.StatusOK)
-					json, err := os.ReadFile("./client/fixtures/search_page_0.json")
-					require.Nil(t, err)
-					_, err = writer.Write(json)
-					if err != nil {
-						return
-					}
-				},
-			),
-		)
+		server := newMockPrivXServer("./client/fixtures/search_page_0.json")
 		defer server.Close()
 
 		privXClient, err := client.NewPrivXClientWithClientSecret(
@@ -53,20 +83,7 @@ func TestUsersList(t *testing.T) {
 	})
 
 	t.Run("should paginate", func(t *testing.T) {
-		server := httptest.NewServer(
-			http.HandlerFunc(
-				func(writer http.ResponseWriter, request *http.Request) {
-					writer.Header().Set(uhttp.ContentType, "application/json")
-					writer.WriteHeader(http.StatusOK)
-					json, err := os.ReadFile("./client/fixtures/search_page_0.json")
-					require.Nil(t, err)
-					_, err = writer.Write(json)
-					if err != nil {
-						return
-					}
-				},
-			),
-		)
+		server := newMockPrivXServer("./client/fixtures/search_page_0.json")
 		defer server.Close()
 
 		privXClient, err := client.NewPrivXClientWithClientSecret(

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/conductorone/baton-privx/pkg/connector/client"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
+	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +43,7 @@ func TestUsersList(t *testing.T) {
 		require.Nil(t, err)
 		userBuilder := newUserBuilder(*privXClient)
 
-		resources, token, annotations, err := userBuilder.List(ctx, nil, &pagination.Token{})
+		resources, results, err := userBuilder.List(ctx, nil, resource.SyncOpAttrs{})
 		require.Nil(t, err)
 
 		// Assert the returned user has an ID.
@@ -51,8 +51,7 @@ func TestUsersList(t *testing.T) {
 		require.Len(t, resources, 3)
 		require.NotEmpty(t, resources[0].Id)
 
-		require.Equal(t, "", token)
-		require.Len(t, annotations, 0)
+		require.Nil(t, results)
 	})
 
 	t.Run("should paginate", func(t *testing.T) {
@@ -83,12 +82,11 @@ func TestUsersList(t *testing.T) {
 		require.Nil(t, err)
 		userBuilder := newUserBuilder(*privXClient)
 
-		paginationToken := pagination.Token{
-			Token: "100",
-			Size:  3,
-		}
+		opts := resource.SyncOpAttrs{}
+		opts.PageToken.Token = "100"
+		opts.PageToken.Size = 3
 
-		resources, token, annotations, err := userBuilder.List(ctx, nil, &paginationToken)
+		resources, results, err := userBuilder.List(ctx, nil, opts)
 		require.Nil(t, err)
 
 		// Assert the returned user has an ID.
@@ -97,8 +95,7 @@ func TestUsersList(t *testing.T) {
 		require.NotEmpty(t, resources[0].Id)
 
 		// Should look for second page.
-		require.Equal(t, "103", token)
-
-		require.Len(t, annotations, 0)
+		require.NotNil(t, results)
+		require.Equal(t, "103", results.NextPageToken)
 	})
 }


### PR DESCRIPTION
Containerizes baton-privx per the containerization guide.
Changes: ConnectorBuilderV2/ResourceSyncerV2 migration, config.go metadata, Makefile BATON_LAMBDA_SUPPORT, main.go RunConnector, CI cleanup.
Linear: CXH-1892

**Note:** `base-url` is marked `WithRequired(true)` even though the C1 spec does not require it. This is a deliberate addition — the connector cannot function without a base URL — but it is a minor schema divergence from the C1 definition and could be considered a breaking change for any saved config that omits the field.