### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -187,11 +187,10 @@ func roleResource(ctx context.Context, role *rolestore.Role) (*v2.Resource, erro
 		role.Name,
 		roleResourceType,
 		role.ID,
-		[]resource.RoleTraitOption{
-			resource.WithRoleProfile(map[string]interface{}{
-				"name": role.Name,
-			}),
-		},
+		[]resource.RoleTraitOption{},
+		resource.WithResourceProfile(map[string]interface{}{
+			"name": role.Name,
+		}),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -96,15 +96,13 @@ func userResource(ctx context.Context, user *rolestore.User) (*v2.Resource, erro
 		userResourceType,
 		user.ID,
 		[]resource.UserTraitOption{
-			resource.WithUserProfile(
-				map[string]interface{}{
-					"full_name": user.FullName,
-					"id":        user.ID,
-				},
-			),
 			resource.WithEmail(user.Email, true),
-			resource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 		},
+		resource.WithResourceProfile(map[string]interface{}{
+			"full_name": user.FullName,
+			"id":        user.ID,
+		}),
+		resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
